### PR TITLE
Support sending large amounts of random data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ A simple (requests.json) example:
     "method": "POST",
     "path": "/",
     "headers": {
-      "Content-Type": "application/x-www-form-urlencoded"
+      "Content-Type": "application/x-www-form-urlencoded",
     },
-    "body": "name=user&email=user@example.com",
+    "body": {
+      "content": "name=user&email=user@example.com",
+    },
     "delay": {
       "min": 3000,
       "max": 5000,
@@ -102,7 +104,11 @@ where the individual `<request>`s are
     ...
     "X-Custom-Header-n": <s>
   },
-  "body": <s>,
+  "body": {
+    "content": <s>,
+    "size": <n>,
+    "type": <s>,
+  },
   "max-requests": <n>,
   "keep-alive-requests": <n>,
   "clients": <n>,
@@ -134,10 +140,19 @@ where the individual `<request>`s are
       system defaults are used.
 * **scheme**: URL scheme (http|https)
 * **tls-session-reuse**: Use TLS session reuse? (true|false)
-* **method**: HTTP method (GET/HEAD/POST/...), see RFC 7231
+* **method**: HTTP method (GET/HEAD/PATCH/POST/PUT...), see RFC 7231
 * **path**: URL path
 * **headers**: an array of custom HTTP headers
 * **body**: HTTP requests body
+  * **content**: Data to send in the HTTP request body when **type** is "content".  For any
+    other **type**, the content is ignored.
+  * **size**: Size of the PRNG body to be sent in the body of the HTTP request.  The size is
+    the real size of the transferred data excluding overhead of the chunked Transfer-Encoding
+    (see RFC 2616).  This field must be set for **type** "random".  For any other **type**,
+    the size is ignored.
+  * **type**: (content|random).  If the type is "content", **content** will be sent in the
+    HTTP request.  If the type is "random", PRNG data with the period of `MAX_REQ_LEN`
+    will be sent.  If the **type** is unset, "content" is assumed.
 * **max-requests**: how many HTTP requests to send to **host** in total.  If the value is 0 or
   unspecified, the requests will be sent for the entire duration of the test.  If there is no more
   HTTP requests to be sent for all hosts, the test may finish earlier than specified.

--- a/src/mcg.c
+++ b/src/mcg.c
@@ -1,0 +1,56 @@
+#include <inttypes.h>		/* UINT64_MAX, uint64_t, ... */
+#include <string.h>		/* memcpy() */
+
+#include "mcg.h"
+
+/* 
+ * A 128-bit truncated MCG PRNG based on:
+ * http://www.pcg-random.org/posts/does-it-beat-the-minimal-standard.html
+ */
+
+const __uint128_t MCG64_MULT = ((__uint128_t)UINT64_MAX + 1) * UINT64_C(0x0fc94e3bf4e9ab32) + UINT64_C(0x866458cd56f5e605);
+
+/* The MCG state must be seeded to an odd number. */
+void mcg64_seed(__uint128_t *state) {
+  *state |= 1;
+}
+
+static inline uint64_t mcg64(__uint128_t *state) {
+  *state *= MCG64_MULT;
+
+  return *state >> 64;
+}
+
+#if 1
+/* mcg64cpy() copies "len" number of pseudo-random bytes into output array "out". */
+void mcg64cpy(__uint128_t *state, char *out, size_t len) {
+  uint64_t rndn;
+  size_t n;
+  const char *out_end = out + len;
+
+  while (1) {
+    rndn = mcg64(state);
+
+    n = (out_end - out) > 8? 8: (out_end - out);
+    memcpy(out, &rndn, n);
+    out += n;
+
+    if (out >= out_end) {
+      return;
+    }
+  }
+}
+#else
+/* only for testing purposes only */
+void mcg64cpy(__uint128_t *state, char *out, size_t len) {
+  const char *out_end = out + len;
+
+  for (int i=0;; i++) {
+    *out = '0' + i % 10;
+
+    if (++out >= out_end) {
+      return;
+    }
+  }
+}
+#endif

--- a/src/mcg.h
+++ b/src/mcg.h
@@ -1,0 +1,5 @@
+#ifndef MCG64_H
+/* Module functions */
+extern void mcg64_seed(__uint128_t *state);
+extern void mcg64cpy(__uint128_t *, char *, size_t);
+#endif /* MCG64_H */


### PR DESCRIPTION
This commit adds support for sending large amounts of PRNG data using chunked Transfer-Encoding.

Note the change in the specification of the request's body. Previously, body was just a string.  Now the following format is used:
```
  "body": {
    "content": <string>,
    "size": <number>,
    "type": "content|random",
  }
```
The old format is still supported for compatibility, but will be removed in future versions.

A typical use to send PNRG data in the request's body is:
```
  "body": {
    "size": <number>,
    "type": "random",
  }
```
