### PR TITLE
Remove make target in Dockerfile build

### DIFF
--- a/containers/Dockerfile.busybox
+++ b/containers/Dockerfile.busybox
@@ -5,7 +5,7 @@ COPY . /mb
 
 RUN yum -y groupinstall 'Development Tools' && \
     cd /mb && \
-    make mb
+    make
 
 # mb container
 FROM busybox:1.30.1-glibc


### PR DESCRIPTION
Dockerfile was failing to properly build due to missing WolfSSL headers

```
cc -Wall -Wno-parentheses -Wno-switch-enum -Wno-unused-value -Wno-error -g -DHAVE_SSL -I/mb/usr/include -c src/ssl.c -o src/ssl.o
In file included from src/ssl.c:7:0:
src/ssl.h:4:76: fatal error: wolfssl/options.h: No such file or directory
 #include <wolfssl/options.h> /* HAVE_SNI, HAVE_SECURE_RENEGOTIATION, ... */
                                                                            ^
compilation terminated.
make: *** [src/ssl.o] Error 1
```